### PR TITLE
Use AsyncOpenAI for order and nutrition services

### DIFF
--- a/bot/services/nutrition.py
+++ b/bot/services/nutrition.py
@@ -1,19 +1,19 @@
 from datetime import datetime
 from typing import Any, Dict, List
 
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 from ..config import get_settings
 from ..database import get_db
 from ..whatsapp import send_message
 
-_client: OpenAI | None = None
+_client: AsyncOpenAI | None = None
 
 
-def _openai() -> OpenAI:
+def _openai() -> AsyncOpenAI:
     global _client
     if _client is None:
-        _client = OpenAI(api_key=get_settings().OPENAI_API_KEY)
+        _client = AsyncOpenAI(api_key=get_settings().OPENAI_API_KEY)
     return _client
 
 
@@ -22,7 +22,7 @@ async def handle(user_id: str, text: str, session: Dict[str, Any]) -> Dict[str, 
     history: List[Dict[str, str]] = session.get("history", [])
     history.append({"role": "user", "content": text})
     try:
-        response = _openai().chat.completions.create(
+        response = await _openai().chat.completions.create(
             model="gpt-4o", messages=history, temperature=0.7
         )
         reply = response.choices[0].message.content

--- a/bot/services/order.py
+++ b/bot/services/order.py
@@ -5,19 +5,19 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 from jinja2 import Template
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 from ..config import get_settings
 from ..database import get_db
 from ..whatsapp import send_message
 
-_client: OpenAI | None = None
+_client: AsyncOpenAI | None = None
 
 
-def _openai() -> OpenAI:
+def _openai() -> AsyncOpenAI:
     global _client
     if _client is None:
-        _client = OpenAI(api_key=get_settings().OPENAI_API_KEY)
+        _client = AsyncOpenAI(api_key=get_settings().OPENAI_API_KEY)
     return _client
 
 
@@ -54,7 +54,7 @@ async def _parse_items(text: str) -> List[Dict[str, Any]]:
         f"Message: {text}"
     )
     try:
-        response = _openai().chat.completions.create(
+        response = await _openai().chat.completions.create(
             model="gpt-4o",
             messages=[{"role": "user", "content": prompt}],
             temperature=0,


### PR DESCRIPTION
## Summary
- switch to `AsyncOpenAI` client
- call OpenAI chat completion APIs asynchronously

## Testing
- `pytest -q`
- `python -m compileall -q bot`


------
https://chatgpt.com/codex/tasks/task_b_68615d6645d88331ac06bc8dcf0c3445