### PR TITLE
Show available items in order prompt

### DIFF
--- a/bot/services/order.py
+++ b/bot/services/order.py
@@ -48,7 +48,11 @@ async def show_menu(user_id: str) -> None:
 
 async def _parse_items(text: str) -> List[Dict[str, Any]]:
     """Use OpenAI to parse free-text order into structured items."""
+    db = get_db()
+    products = await db.food_products.find({"is_available": True}).to_list(length=None)
+    names = ", ".join(p.get("name") for p in products)
     prompt = (
+        f"Available items: {names}\n"
         "Extract food items and their quantities from this message. "
         "Respond only with valid JSON in the form {'items': [{'product': '', 'quantity': 1}]}.\n"
         f"Message: {text}"


### PR DESCRIPTION
## Summary
- enhance `_parse_items` to fetch product names
- list available item names in the prompt to OpenAI

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68615d7c23c483319a898210f3320de6