### PR TITLE
Support changing orders

### DIFF
--- a/bot/services/order.py
+++ b/bot/services/order.py
@@ -15,13 +15,15 @@ CONFIRM_TEMPLATE = Template(
     "✅ Got your order:\n"
     "{% for item in items %}- {{item.quantity}}x {{item.name}} @ ₦{{item.unit_price}}\n{% endfor %}"
     "Total: ₦{{total}}\n"
-    "Please confirm (yes/no)"
+    "Please confirm (yes/no) or type 'change' to edit"
 )
 
 
 # accepted yes/no variants
 YES_WORDS = {"y", "yes", "sure", "ok"}
 NO_WORDS = {"n", "no", "nah"}
+# words indicating the user wants to change the order
+CHANGE_WORDS = {"change", "edit"}
 
 
 async def show_menu(user_id: str) -> None:
@@ -169,7 +171,14 @@ async def handle(user_id: str, text: str, session: Dict[str, Any]) -> Dict[str, 
                 {"$set": {"step": "await_items", "updated_at": datetime.utcnow()}},
             )
             return {"status": "awaiting"}
-        await send_message(user_id, "Please reply with yes or no.")
+        if response in CHANGE_WORDS:
+            await send_message(user_id, "Okay, please retype your order message.")
+            await db.sessions.update_one(
+                {"user_id": user_id},
+                {"$set": {"step": "await_items", "updated_at": datetime.utcnow()}},
+            )
+            return {"status": "awaiting"}
+        await send_message(user_id, "Please reply with yes or no, or type 'change'.")
         return {"status": "awaiting"}
 
     if step == "await_address":
@@ -184,7 +193,10 @@ async def handle(user_id: str, text: str, session: Dict[str, Any]) -> Dict[str, 
                 }
             },
         )
-        await send_message(user_id, f"You entered: {text}\nIs this correct? (yes/no)")
+        await send_message(
+            user_id,
+            f"You entered: {text}\nIs this correct? (yes/no) or type 'change' to edit",
+        )
         return {"status": "awaiting"}
 
     if step == "confirm_address":

--- a/tests/test_change.py
+++ b/tests/test_change.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from bot.services import order
+
+
+class DummySettings:
+    DELIVERY_PHONE_NUMBER = None
+
+class DummyCollection:
+    def __init__(self):
+        self.updated = []
+    async def update_one(self, filt, update):
+        self.updated.append(update)
+
+class DummyDB:
+    def __init__(self):
+        self.sessions = DummyCollection()
+
+def fake_get_db():
+    return DummyDB()
+
+@pytest.mark.asyncio
+async def test_change_moves_to_await_items(monkeypatch):
+    db = DummyDB()
+    monkeypatch.setattr(order, "get_db", lambda: db)
+    monkeypatch.setattr(order, "get_settings", lambda: DummySettings())
+    messages = []
+    async def fake_send_message(uid, txt):
+        messages.append(txt)
+    monkeypatch.setattr(order, "send_message", fake_send_message)
+
+    session = {"step": "await_confirm", "data": {}}
+    res = await order.handle("u", "change", session)
+    assert res["status"] == "awaiting"
+    assert db.sessions.updated
+    assert db.sessions.updated[-1]["$set"]["step"] == "await_items"
+


### PR DESCRIPTION
## Summary
- allow users to type `change` when confirming an order
- mention the change option in confirmation messages
- test that `change` restarts the item entry flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863a7fbed7c83318660363af0227232