### PR TITLE
Add retry logic for WhatsApp and OpenAI

### DIFF
--- a/bot/ai_client.py
+++ b/bot/ai_client.py
@@ -1,5 +1,7 @@
 """Centralized AI services for the WhatsApp bot."""
 
+import asyncio
+import logging
 from openai import AsyncOpenAI
 
 from .config import get_settings
@@ -14,3 +16,17 @@ def get_openai_client() -> AsyncOpenAI:
         settings = get_settings()
         _client = AsyncOpenAI(api_key=settings.API_KEY)
     return _client
+
+
+async def create_chat_completion(*args, retries: int = 3, backoff: float = 1.0, **kwargs):
+    """Wrapper around OpenAI chat completion with retries."""
+    client = get_openai_client()
+    for attempt in range(1, retries + 1):
+        try:
+            return await client.chat.completions.create(*args, **kwargs)
+        except Exception as exc:
+            logging.exception("OpenAI attempt %s failed", attempt)
+            if attempt == retries:
+                logging.exception("OpenAI request failed after %s attempts", retries)
+                raise
+            await asyncio.sleep(backoff * 2 ** (attempt - 1))

--- a/bot/services/nutrition.py
+++ b/bot/services/nutrition.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Any, Dict, List
 
-from ..ai_client import get_openai_client
+from ..ai_client import create_chat_completion
 from ..config import get_settings
 from ..database import get_db
 from ..whatsapp import send_message
@@ -12,7 +12,7 @@ async def handle(user_id: str, text: str, session: Dict[str, Any]) -> Dict[str, 
     history: List[Dict[str, str]] = session.get("history", [])
     history.append({"role": "user", "content": text})
     try:
-        response = await get_openai_client().chat.completions.create(
+        response = await create_chat_completion(
             model=get_settings().MODEL_MODEL, messages=history, temperature=0.7
         )
         reply = response.choices[0].message.content

--- a/bot/services/order.py
+++ b/bot/services/order.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 from jinja2 import Template
-from ..ai_client import get_openai_client
+from ..ai_client import create_chat_completion
 from ..config import get_settings
 from ..database import get_db
 from ..whatsapp import send_message
@@ -53,7 +53,7 @@ async def _parse_items(text: str) -> List[Dict[str, Any]]:
         f"Message: {text}"
     )
     try:
-        response = await get_openai_client().chat.completions.create(
+        response = await create_chat_completion(
             model=get_settings().MODEL_MODEL,
             messages=[{"role": "user", "content": prompt}],
             temperature=0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,3 +55,5 @@ uvloop==0.21.0
 watchfiles==1.1.0
 websockets==15.0.1
 yarl==1.20.0
+pytest==8.2.1
+pytest-asyncio==0.23.6

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,52 @@
+import asyncio
+import types
+import httpx
+import logging
+import pytest
+
+from bot import whatsapp, ai_client
+
+class DummySettings:
+    WHATSAPP_PHONE_NUMBER_ID = "id"
+    WHATSAPP_ACCESS_TOKEN = "token"
+
+@pytest.mark.asyncio
+async def test_send_message_retries(monkeypatch, caplog):
+    attempts = 0
+
+    async def fake_post(url, json=None, headers=None):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise httpx.ConnectError('fail', request=httpx.Request('POST', url))
+        return httpx.Response(200, request=httpx.Request('POST', url))
+
+    monkeypatch.setattr(whatsapp, "_client", types.SimpleNamespace(post=fake_post))
+    monkeypatch.setattr(whatsapp, "get_settings", lambda: DummySettings())
+    caplog.set_level(logging.ERROR)
+    await whatsapp.send_message('123', 'hi', retries=3, backoff=0)
+    assert attempts == 3
+    assert sum('attempt 1 failed' in r.getMessage() for r in caplog.records) == 1
+    assert sum('attempt 2 failed' in r.getMessage() for r in caplog.records) == 1
+
+@pytest.mark.asyncio
+async def test_create_chat_completion_retries(monkeypatch, caplog):
+    attempts = 0
+
+    async def fake_create(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise Exception('temp')
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='ok'))])
+
+    fake_client = types.SimpleNamespace(chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=fake_create)))
+    monkeypatch.setattr(ai_client, 'get_openai_client', lambda: fake_client)
+    monkeypatch.setattr(ai_client, 'get_settings', lambda: DummySettings())
+
+    caplog.set_level(logging.ERROR)
+    resp = await ai_client.create_chat_completion(model='gpt', messages=[] , retries=3, backoff=0)
+    assert attempts == 3
+    assert resp.choices[0].message.content == 'ok'
+    assert sum('attempt 1 failed' in r.getMessage() for r in caplog.records) == 1
+    assert sum('attempt 2 failed' in r.getMessage() for r in caplog.records) == 1


### PR DESCRIPTION
## Summary
- wrap WhatsApp `send_message` in retry loop with exponential backoff
- add `create_chat_completion` helper with retries
- update services to use retry helpers
- include tests to verify retry behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863a9557ba48331b239b459adae219e